### PR TITLE
Updating CONFIG_PROPERTIES_BLACKLIST_DEFAULT value, WRITE ACL filter & default header converter change

### DIFF
--- a/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
+++ b/connect/mirror-client/src/main/java/org/apache/kafka/connect/mirror/MirrorMakerConfig.java
@@ -63,6 +63,7 @@ public class MirrorMakerConfig extends AbstractConfig {
     private static final String CONFIG_TOPIC_CONFIG = "config.storage.topic";
     private static final String KEY_CONVERTER_CLASS_CONFIG = "key.converter";
     private static final String VALUE_CONVERTER_CLASS_CONFIG = "value.converter";
+    private static final String HEADER_CONVERTER_CLASS_CONFIG = "header.converter";
     private static final String BYTE_ARRAY_CONVERTER_CLASS =
         "org.apache.kafka.connect.converters.ByteArrayConverter";
 
@@ -176,6 +177,9 @@ public class MirrorMakerConfig extends AbstractConfig {
         }
         if (!props.containsKey(VALUE_CONVERTER_CLASS_CONFIG)) {
             props.put(VALUE_CONVERTER_CLASS_CONFIG, BYTE_ARRAY_CONVERTER_CLASS); 
+        }
+        if (!props.containsKey(HEADER_CONVERTER_CLASS_CONFIG)) {
+            props.put(HEADER_CONVERTER_CLASS_CONFIG, BYTE_ARRAY_CONVERTER_CLASS);
         }
 
         return props;

--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/DefaultConfigPropertyFilter.java
@@ -31,7 +31,12 @@ public class DefaultConfigPropertyFilter implements ConfigPropertyFilter, Config
     public static final String CONFIG_PROPERTIES_BLACKLIST_CONFIG = "config.properties.blacklist";
     private static final String CONFIG_PROPERTIES_BLACKLIST_DOC = "List of topic configuration properties and/or regexes "
         + "that should not be replicated.";
-    public static final String CONFIG_PROPERTIES_BLACKLIST_DEFAULT = "segment\\.bytes, min\\.insync\\.replicas";
+    public static final String CONFIG_PROPERTIES_BLACKLIST_DEFAULT = "follower\\.replication\\.throttled\\.replicas, "
+        + "leader\\.replication\\.throttled\\.replicas, "
+        + "message\\.timestamp\\.difference\\.max\\.ms, "
+        + "message\\.timestamp\\.type, "
+        + "unclean\\.leader\\.election\\.enable, "
+        + "min\\.insync\\.replicas";
 
     private Pattern blacklistPattern;
 


### PR DESCRIPTION
Some more configs which doesn't make sense to be replicated to target cluster.
throttled.replicas -> need not map to same broker ids in target
message.timestamp.difference.max.ms -> might cause message drops if not adjusted for replication delays
unclean.leader.election.enable -> one would prefer more consistency over availability on a backup replica.


As per KIP-382 target topic should be writable by MM2 only, so second commit adds another filter to prevent ALLOW WRITE acl sync. ALLOW ALL acls are modified to ALLOW READ upon syncing.

The default SimpleHeaderConverter converts byte[] into base64 upon read and pass it as such upon write, so one commit to make ByteArrayConverter the default for headers too.