### PR TITLE
Refresh knownTargetTopic state at startup after createTopicPartitions

### DIFF
--- a/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
+++ b/connect/mirror/src/main/java/org/apache/kafka/connect/mirror/MirrorSourceConnector.java
@@ -107,6 +107,7 @@ public class MirrorSourceConnector extends SourceConnector {
         scheduler.execute(this::createOffsetSyncsTopic, "creating upstream offset-syncs topic");
         scheduler.execute(this::loadTopicPartitions, "loading initial set of topic-partitions");
         scheduler.execute(this::createTopicPartitions, "creating downstream topic-partitions");
+        scheduler.execute(this::refreshKnownTargetTopics, "refreshing known target topics");
         scheduler.scheduleRepeating(this::syncTopicAcls, config.syncTopicAclsInterval(), "syncing topic ACLs");
         scheduler.scheduleRepeating(this::syncTopicConfigs, config.syncTopicConfigsInterval(),
             "syncing topic configs");
@@ -192,6 +193,11 @@ public class MirrorSourceConnector extends SourceConnector {
             throws InterruptedException, ExecutionException {
         knownTopicPartitions = findTopicPartitions();
         knownTargetTopics = findExistingTargetTopics(); 
+    }
+
+    private void refreshKnownTargetTopics()
+            throws InterruptedException, ExecutionException {
+        knownTargetTopics = findExistingTargetTopics();
     }
 
     private Set<String> findExistingTargetTopics()


### PR DESCRIPTION
knownTargetTopics state is currently only refreshed at two occasions:
* startup of the connector, before topics in downstream cluster are
created and therefore stays empty
* new partitions/ dead partitions in upstream cluster are found.

In the case of no creation of new partitions in upstream cluster, the
state remains empty, which blocks config syncing.

I therefore propose a new method refreshKnownTargetTopics,
which is executed after createTopicPartitions in downstream cluster and
initially fills the state, to enable config syncing from the start.